### PR TITLE
Remove module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",
-  "type": "module",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Address module type, Vite deprecation, and potential issue occurring in Next.js builds per #40.

